### PR TITLE
Use snapshot versions of Vitruvius dependencies

### DIFF
--- a/.github/prepare-release
+++ b/.github/prepare-release
@@ -9,13 +9,16 @@ then
     return 1
 fi
 
+vitruv_property_name="vitruv.version"
+
 git switch -C prepare-release/$1 || exit 1
 
 set_version_and_commit() {
     ./mvnw versions:set -DnewVersion=$1 -DgenerateBackupPoms=false || return 1
+    ./mvnw versions:set-property -Dproperty=$vitruv_property_name -DnewVersion=$1 -DgenerateBackupPoms=false || return 1
 
     git add pom.xml || return 1
-    git add "**/pom.xml" 2> /dev/null
+    git add "**/pom.xml" 2> /dev/null || return 1
 
     git commit -m "$2" || return 1
 }

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   </modules>
 
   <properties>
-    <vitruv.version>3.1.2</vitruv.version>
+    <vitruv.version>3.2.0-SNAPSHOT</vitruv.version>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>vitruv-tools</sonar.organization>
     <sonar.projectKey>vitruv-tools_Vitruv-Server</sonar.projectKey>
@@ -143,4 +143,18 @@
     </dependencies>
   </dependencyManagement>
 
+  <repositories>
+    <!-- allow snapshots -->
+    <repository>
+      <id>ossrh-snapshots</id>
+      <name>OSSRH Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+  </repositories>
 </project>

--- a/remote/src/main/java/tools/vitruv/framework/remote/client/impl/ChangeRecordingRemoteView.java
+++ b/remote/src/main/java/tools/vitruv/framework/remote/client/impl/ChangeRecordingRemoteView.java
@@ -6,7 +6,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 
 import tools.vitruv.change.composite.description.TransactionalChange;
-import tools.vitruv.change.composite.description.VitruviusChangeResolver;
+import tools.vitruv.change.composite.description.VitruviusChangeResolverFactory;
 import tools.vitruv.change.composite.recording.ChangeRecorder;
 import tools.vitruv.change.interaction.UserInteractionBase;
 import tools.vitruv.framework.views.CommittableView;
@@ -121,7 +121,7 @@ public class ChangeRecordingRemoteView implements CommittableView {
     public void commitChanges() {
         base.checkNotClosed();
         var recordedChange = changeRecorder.endRecording();
-        var changeResolver = VitruviusChangeResolver.forHierarchicalIds(base.viewSource);
+        var changeResolver = VitruviusChangeResolverFactory.forHierarchicalIds(base.viewSource);
         var unresolvedChanges = changeResolver.assignIds(recordedChange);
         base.remoteConnection.propagateChanges(base.uuid, unresolvedChanges);
         base.modified = false;
@@ -131,7 +131,7 @@ public class ChangeRecordingRemoteView implements CommittableView {
     public void commitChanges(Iterable<UserInteractionBase> userInputs) {
     	 base.checkNotClosed();
          var recordedChange = changeRecorder.endRecording();
-         var changeResolver = VitruviusChangeResolver.forHierarchicalIds(base.viewSource);
+         var changeResolver = VitruviusChangeResolverFactory.forHierarchicalIds(base.viewSource);
          var unresolvedChanges = changeResolver.assignIds(recordedChange);
          ((TransactionalChange<?>) unresolvedChanges).setUserInteractions(userInputs);
          base.remoteConnection.propagateChanges(base.uuid, unresolvedChanges);


### PR DESCRIPTION
Allows us to verify in nightly builds that change in one module don't break internal dependencies. Release version is automatically set in the `prepare-release` script.