### PR TITLE
Closes several minor issues

### DIFF
--- a/remote/src/main/java/tools/vitruv/framework/remote/client/impl/VitruvRemoteConnection.java
+++ b/remote/src/main/java/tools/vitruv/framework/remote/client/impl/VitruvRemoteConnection.java
@@ -39,6 +39,11 @@ import tools.vitruv.framework.views.ViewType;
  * server. This enables the ability to perform actions on this remote Vitruvius instance.
  */
 public class VitruvRemoteConnection implements VitruvClient {
+    private static final String SUCCESS = "success";
+    private static final String EXCEPTION = "exception";
+    private static final String RESULT = "result";
+    private static final String METHOD = "method";
+    private static final String ENDPOINT = "endpoint";
     private static final String METRIC_CLIENT_NAME = "vitruv.client.rest.client";
     private final int port;
     private final String hostOrIp;
@@ -276,20 +281,20 @@ public class VitruvRemoteConnection implements VitruvClient {
         try {
             var response = client.send(request, BodyHandlers.ofString());
             if (response.statusCode() != HttpURLConnection.HTTP_OK) {
-                timer.stop(Metrics.timer(METRIC_CLIENT_NAME, "endpoint", request.uri().getPath(),
-                        "method", request.method(), "result", "" + response.statusCode()));
+                timer.stop(Metrics.timer(METRIC_CLIENT_NAME, ENDPOINT, request.uri().getPath(),
+                        METHOD, request.method(), RESULT, "" + response.statusCode()));
                 throw new BadServerResponseException(response.body(), response.statusCode());
             }
-            timer.stop(Metrics.timer(METRIC_CLIENT_NAME, "endpoint", request.uri().getPath(),
-                    "method", request.method(), "result", "success"));
+            timer.stop(Metrics.timer(METRIC_CLIENT_NAME, ENDPOINT, request.uri().getPath(),
+                    METHOD, request.method(), RESULT, SUCCESS));
             return response;
         } catch (IOException e) {
-            timer.stop(Metrics.timer(METRIC_CLIENT_NAME, "endpoint", request.uri().getPath(),
-                    "method", request.method(), "result", "exception"));
+            timer.stop(Metrics.timer(METRIC_CLIENT_NAME, ENDPOINT, request.uri().getPath(),
+                    METHOD, request.method(), RESULT, EXCEPTION));
             throw new BadServerResponseException(e);
         } catch (InterruptedException e) {
-            timer.stop(Metrics.timer(METRIC_CLIENT_NAME, "endpoint", request.uri().getPath(),
-                    "method", request.method(), "result", "exception"));
+            timer.stop(Metrics.timer(METRIC_CLIENT_NAME, ENDPOINT, request.uri().getPath(),
+                    METHOD, request.method(), RESULT, EXCEPTION));
             Thread.currentThread().interrupt(); // Re-interrupt the current thread
             throw new BadServerResponseException(e);
         }

--- a/remote/src/main/java/tools/vitruv/framework/remote/common/json/deserializer/ReferenceDeserializerModifier.java
+++ b/remote/src/main/java/tools/vitruv/framework/remote/common/json/deserializer/ReferenceDeserializerModifier.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.type.ReferenceType;
 import tools.vitruv.framework.remote.common.json.IdTransformation;
 
 public class ReferenceDeserializerModifier extends BeanDeserializerModifier {
-	private final IdTransformation transformation;
+	private transient final IdTransformation transformation;
 	
 	public ReferenceDeserializerModifier(IdTransformation transformation) {
 		this.transformation = transformation;

--- a/remote/src/main/java/tools/vitruv/framework/remote/common/json/deserializer/ReferenceDeserializerModifier.java
+++ b/remote/src/main/java/tools/vitruv/framework/remote/common/json/deserializer/ReferenceDeserializerModifier.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.type.ReferenceType;
 import tools.vitruv.framework.remote.common.json.IdTransformation;
 
 public class ReferenceDeserializerModifier extends BeanDeserializerModifier {
-	private transient final IdTransformation transformation;
+	private final transient IdTransformation transformation;
 	
 	public ReferenceDeserializerModifier(IdTransformation transformation) {
 		this.transformation = transformation;

--- a/remote/src/main/java/tools/vitruv/framework/remote/common/json/deserializer/VitruviusChangeDeserializer.java
+++ b/remote/src/main/java/tools/vitruv/framework/remote/common/json/deserializer/VitruviusChangeDeserializer.java
@@ -23,7 +23,7 @@ import tools.vitruv.framework.remote.common.json.JsonMapper;
 import tools.vitruv.framework.remote.common.util.ResourceUtil;
 
 public class VitruviusChangeDeserializer extends JsonDeserializer<VitruviusChange<?>> {
-	private transient final IdTransformation transformation;
+	private final IdTransformation transformation;
 	private final JsonMapper mapper;
 	
     public VitruviusChangeDeserializer(JsonMapper mapper, IdTransformation transformation) {

--- a/remote/src/main/java/tools/vitruv/framework/remote/common/json/deserializer/VitruviusChangeDeserializer.java
+++ b/remote/src/main/java/tools/vitruv/framework/remote/common/json/deserializer/VitruviusChangeDeserializer.java
@@ -23,7 +23,7 @@ import tools.vitruv.framework.remote.common.json.JsonMapper;
 import tools.vitruv.framework.remote.common.util.ResourceUtil;
 
 public class VitruviusChangeDeserializer extends JsonDeserializer<VitruviusChange<?>> {
-	private final IdTransformation transformation;
+	private transient final IdTransformation transformation;
 	private final JsonMapper mapper;
 	
     public VitruviusChangeDeserializer(JsonMapper mapper, IdTransformation transformation) {

--- a/remote/src/main/java/tools/vitruv/framework/remote/common/json/serializer/ReferenceSerializerModifier.java
+++ b/remote/src/main/java/tools/vitruv/framework/remote/common/json/serializer/ReferenceSerializerModifier.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import tools.vitruv.framework.remote.common.json.IdTransformation;
 
 public class ReferenceSerializerModifier extends BeanSerializerModifier {
-	private final IdTransformation transformation;
+	private final transient IdTransformation transformation;
 	
 	public ReferenceSerializerModifier(IdTransformation transformation) {
 		this.transformation = transformation;


### PR DESCRIPTION
Closes https://github.com/vitruv-tools/Vitruv-Server/issues/15, https://github.com/vitruv-tools/Vitruv-Server/issues/16, https://github.com/vitruv-tools/Vitruv-Server/issues/11, https://github.com/vitruv-tools/Vitruv-Server/issues/12, https://github.com/vitruv-tools/Vitruv-Server/issues/13. Made the reference transient because the IdTransformation depends on local information, thus, in general, it makes no sense for it to be serialized and deserialized on a different machine.